### PR TITLE
add external dependency map for crypto packages

### DIFF
--- a/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/standardConfigurationProperties.ts
+++ b/packages/service-types-generator/src/ServiceCustomizations/customizationsFromModel/standardConfigurationProperties.ts
@@ -1,4 +1,5 @@
 import { IMPORTS } from '../../internalImports';
+import { EXTERNAL_IMPORTS } from '../../externalImports';
 import { packageNameToVariable } from '../../packageNameToVariable';
 import {
     normalizeStaticOrProvider,
@@ -250,7 +251,7 @@ export const sha256: ConfigurationPropertyDefinition = {
     documentation: 'A constructor for a class implementing the @aws-sdk/types.Hash interface that computes the SHA-256 HMAC or checksum of a string or binary buffer',
     browser: {
         required: false,
-        imports: [IMPORTS['crypto-sha256-browser']],
+        imports: [EXTERNAL_IMPORTS['sha256-browser']],
         default: {
             type: 'value',
             expression: `${packageNameToVariable('@aws-crypto/sha256-browser')}.Sha256`,
@@ -266,7 +267,7 @@ export const sha256: ConfigurationPropertyDefinition = {
     },
     universal: {
         required: false,
-        imports: [IMPORTS['crypto-sha256-universal']],
+        imports: [EXTERNAL_IMPORTS['sha256-universal']],
         default: {
             type: 'value',
             expression: `${packageNameToVariable('@aws-crypto/sha256-universal')}.Sha256`,

--- a/packages/service-types-generator/src/externalImports.ts
+++ b/packages/service-types-generator/src/externalImports.ts
@@ -1,0 +1,43 @@
+import {Import} from '@aws-sdk/build-types';
+
+/**
+ * @internal
+ */
+export const EXTERNAL_IMPORTS: {[key: string]: Import} = {
+    'crc32': {
+        package: '@aws-crypto/crc32',
+        version: '^0.1.0-preview.1',
+    },
+    'ie11-detection': {
+        package: '@aws-crypto/ie11-detection',
+        version: '^0.1.0-preview.1',
+    },
+    'random-source-browser': {
+        package: '@aws-crypto/random-source-browser',
+        version: '^0.1.0-preview.1',
+    },
+    'random-source-node': {
+        package: '@aws-crypto/random-source-node',
+        version: '^0.1.0-preview.1',
+    },
+    'random-source-universal': {
+        package: '@aws-crypto/random-source-universal',
+        version: '^0.1.0-preview.1',
+    },
+    'sha256-browser': {
+        package: '@aws-crypto/sha256-browser',
+        version: '^0.1.0-preview.1',
+    },
+    'sha256-js': {
+        package: '@aws-crypto/sha256-js',
+        version: '^0.1.0-preview.1',
+    },
+    'sha256-universal': {
+        package: '@aws-crypto/sha256-universal',
+        version: '^0.1.0-preview.1',
+    },
+    'supports-webCrypto': {
+        package: '@aws-crypto/supports-webCrypto',
+        version: '^0.1.0-preview.1',
+    },
+};


### PR DESCRIPTION
The `service-types-generator` package will autogen the internalImport map everytime when you run test script. I put all the crypto package to another external imports map to resolve these maps.

/cc @seebees 